### PR TITLE
chore: update Go version to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module ShadowTest
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/getsentry/sentry-go v0.46.2


### PR DESCRIPTION
## Go version update

Bumps Go to **1.26.4**.

### Changes
- go.mod: go 1.26.3 → go 1.26.4

_Automated PR by update-go-version.sh_