### PR TITLE
chore: update Go version to 1.26.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine AS build
+FROM golang:1.26.5-alpine AS build
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module ShadowTest
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/getsentry/sentry-go v0.47.0


### PR DESCRIPTION
## Go version update

Bumps Go to **1.26.5**.

### Changes
- go.mod: go 1.26.4 → go 1.26.5
- Dockerfile: golang:1.26.4 → golang:1.26.5

_Automated PR by update-go-version.sh_